### PR TITLE
CD-85212 Modify PullRequest Plugin to cycle through multiple credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,12 @@
       <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.cthul</groupId>
+      <artifactId>cthul-matchers</artifactId>
+      <version>1.1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/cloudbees/plugins/credentials/matchers/IdPrefixMatcher.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/matchers/IdPrefixMatcher.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2012, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.matchers;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.commons.lang.StringEscapeUtils;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+/**
+ * Matches all of the supplied matchers.
+ *
+ * @since 1.5
+ */
+public class IdPrefixMatcher implements CredentialsMatcher, CredentialsMatcher.CQL {
+    /**
+     * Standardize serialization.
+     *
+     * @since 2.1.0
+     */
+    @NonNull
+    private final Pattern regex_pattern;
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param regex_pattern the pattern to match 
+     */
+    public IdPrefixMatcher(@NonNull String regex_pattern) { 
+        this.regex_pattern = Pattern.compile(regex_pattern);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean matches(@NonNull Credentials item) {
+        Matcher m = regex_pattern.matcher(((IdCredentials) item).getId());
+        return item instanceof IdCredentials && m.matches();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String describe() {
+        return regex_pattern.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return regex_pattern.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        IdPrefixMatcher that = (IdPrefixMatcher) o;
+
+        return regex_pattern.equals(that.regex_pattern);
+
+    }
+
+     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("IdPrefixMatcher{");
+        sb.append("regex_pattern='").append(regex_pattern).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsMatchersTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsMatchersTest.java
@@ -1,12 +1,17 @@
 package com.cloudbees.plugins.credentials;
 
 import com.cloudbees.plugins.credentials.common.UsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import com.cloudbees.plugins.credentials.matchers.CQLSyntaxException;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.cthul.matchers.CthulMatchers.*;
+import static org.mockito.Mockito.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class CredentialsMatchersTest {
 
@@ -15,6 +20,7 @@ public class CredentialsMatchersTest {
         assertThat(CredentialsMatchers.describe(CredentialsMatchers.always()), is("true"));
         assertThat(CredentialsMatchers.describe(CredentialsMatchers.never()), is("false"));
         assertThat(CredentialsMatchers.describe(CredentialsMatchers.withId("target=\"foo\"")), is("(id == \"target=\\\"foo\\\"\")"));
+        assertThat(CredentialsMatchers.describe(CredentialsMatchers.withIdPrefix("test-ghprb-auth1")), matchesPattern("^test-ghprb-auth[0-9]+.*"));
         assertThat(CredentialsMatchers.describe(CredentialsMatchers.allOf(
                 CredentialsMatchers.anyOf(
                         CredentialsMatchers.instanceOf(UsernameCredentials.class),
@@ -98,6 +104,47 @@ public class CredentialsMatchersTest {
         assertThat(instance.matches(new MyBaseStandardCredentials("bob")), is(true));
         assertThat(instance.matches(new MyBaseStandardCredentials("ben")), is(false));
         assertThat(instance.matches(new BaseStandardCredentials(null, null) {}), is(false));
+    }
+
+    @Test
+    public void testCyclic() throws Exception{
+        String ghprbCredentialsIdPattern = "^test-ghprb-auth[0-9]+.*";
+        List<StandardCredentials> credentials = new ArrayList<StandardCredentials>();
+
+        StandardCredentials cred1 = mock(StandardCredentials.class);
+        StandardCredentials cred2 = mock(StandardCredentials.class);
+        StandardCredentials cred3 = mock(StandardCredentials.class);
+        
+        // Mock the value of the credentials
+        when(cred1.getId()).thenReturn("test-ghprb-auth1");
+        when(cred2.getId()).thenReturn("test-ghprb-auth2");
+        when(cred3.getId()).thenReturn("sampleId");
+
+        credentials.add(cred1);
+        credentials.add(cred2);
+        credentials.add(cred3);
+       
+        // Sample asserts to check for the cyclic rotation of the credentials with the matching prefix
+        assertThat(CredentialsMatchers.cyclic(credentials, 
+                                CredentialsMatchers.withIdPrefix(ghprbCredentialsIdPattern), 
+                                                     CredentialsMatchers.withId("sampleId")), is(cred2));
+
+        assertThat(CredentialsMatchers.cyclic(credentials, 
+                                CredentialsMatchers.withIdPrefix(ghprbCredentialsIdPattern), 
+                                                     CredentialsMatchers.withId("sampleId")), is(cred1));
+
+        assertThat(CredentialsMatchers.cyclic(credentials, 
+                                CredentialsMatchers.withIdPrefix(ghprbCredentialsIdPattern), 
+                                                     CredentialsMatchers.withId("sampleId")), is(cred2));
+
+        // Sample assert to return the selected credential(from UI) if the id prefixes does not match the regex 
+        when(cred1.getId()).thenReturn("dummyId1");
+        when(cred2.getId()).thenReturn("dummyId2");
+        
+        assertThat(CredentialsMatchers.cyclic(credentials, 
+                                CredentialsMatchers.withIdPrefix(ghprbCredentialsIdPattern), 
+                                                     CredentialsMatchers.withId("sampleId")), is(cred3));
+
     }
 
     public static class MyBaseStandardCredentials extends BaseStandardCredentials {


### PR DESCRIPTION
## JIRA

* [Issue Link](https://coupadev.atlassian.net/browse/CD-85212)

## Code Reviewers
- [x] @tjackiw 
- [x] @edk

## Summary of change
-  The changes made here are used by the [ghprb plugin](https://github.com/coupa/ghprb-plugin/pull/1)  
- Added a new matcher `IdPrefixMatcher.java` which takes in a input string(Regex) and returns true if the id of the credentials matches the regex.
- Added a new method `cyclic` in `CredentialsMatchers.java` which takes the credentials with the specified id prefix (here `cycle-ghprb-auth*`) and returns the token in a cyclic manner for making the api calls